### PR TITLE
Added tests for json endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,18 @@ This shared example will also infer your factory name from your model, so if you
 ````ruby
 it_behaves_like 'a resourceful controller', User, factory: :admin
 ````
+
+### JSON
+
+By default, the shared example assumes html format for all views, but you can override that for each view, to test json endpoints:
+
+````ruby
+it_behaves_like 'a resourceful controller', User, endpoint_formats: { index: :json }
+````
+
+That will test the following:
+
+| Controller Method | request      | Tests |
+|-------------------|-----------|-------|
+| `index`           | `GET /<resource>` | The right number of objects is returned |
+| `show`            | `GET /<resource>/:id` | The correct attributes are returned |

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ it_behaves_like 'a resourceful controller', User, factory: :admin
 By default, the shared example assumes html format for all views, but you can override that for each view, to test json endpoints:
 
 ````ruby
-it_behaves_like 'a resourceful controller', User, endpoint_formats: { index: :json }
+it_behaves_like 'a resourceful controller', User, formats: { index: [:html, :json] }
 ````
 
 That will test the following:

--- a/lib/rspec_controller_helpers/resourceful.rb
+++ b/lib/rspec_controller_helpers/resourceful.rb
@@ -1,23 +1,43 @@
 RSpec.shared_examples_for 'a resourceful controller' do |model, raw_options|
-  let(:options) { raw_options || {} }
+  let(:options) { ({ endpoint_formats: {} }).merge(raw_options) }
   let(:symbol) { options[:symbol] || model.name.downcase.to_sym }
   let(:factory) { options[:factory] || symbol }
 
-  let(:tests) do
+  let(:endpoints_to_test) do
     all = [:index, :new, :create, :show, :edit, :update, :delete]
     except = options[:except] || []
     options[:only] || (all - except)
   end
 
+  let(:endpoint_formats) do
+    endpoints_to_test
+      .map{|t| { t => :html } }
+      .reduce(:merge)
+      .merge(options[:endpoint_formats])
+  end
+
+  let(:json_response) { JSON.parse(response.body) }
+
   describe "GET /<resource>" do
     let!(:objects) { create_list(factory, 3) }
     subject { get :index }
 
-    it "renders the index page" do
-      if tests.include? :index
+    it 'is successful' do
+      if endpoints_to_test.include? :index
         subject
         expect(response).to have_http_status(:ok)
-        expect(response).to render_template(:index)
+      end
+    end
+
+    it "renders the index page" do
+      if endpoints_to_test.include? :index
+        subject
+        case endpoint_formats[:index]
+        when :html
+          expect(response).to render_template(:index)
+        when :json
+          expect(json_response.length).to eq(3)
+        end
       end
     end
   end
@@ -25,11 +45,20 @@ RSpec.shared_examples_for 'a resourceful controller' do |model, raw_options|
   describe "GET /<resource>/new" do
     subject { get :new }
 
-    it "renders the new page" do
-      if tests.include? :new
+    it 'is successful' do
+      if endpoints_to_test.include? :new
         subject
         expect(response).to have_http_status(:ok)
-        expect(response).to render_template(:new)
+      end
+    end
+
+    it "renders the new page" do
+      if endpoints_to_test.include? :new
+        subject
+        case endpoint_formats[:new]
+        when :html
+          expect(response).to render_template(:new)
+        end
       end
     end
   end
@@ -39,7 +68,7 @@ RSpec.shared_examples_for 'a resourceful controller' do |model, raw_options|
     subject { post :create, symbol => attributes }
 
     it "creates a new object" do
-      if tests.include? :create
+      if endpoints_to_test.include? :create
         expect { subject }.to change { model.count }.by(1)
       end
     end
@@ -49,11 +78,24 @@ RSpec.shared_examples_for 'a resourceful controller' do |model, raw_options|
     let(:object) { create(factory) }
     subject { get :show, id: object.id }
 
-    it "renders the show page" do
-      if tests.include? :show
+    it 'is successful' do
+      if endpoints_to_test.include? :show
         subject
         expect(response).to have_http_status(:ok)
-        expect(response).to render_template(:show)
+      end
+    end
+
+    it "renders the show page" do
+      if endpoints_to_test.include? :show
+        subject
+        case endpoint_formats[:show]
+        when :html
+          expect(response).to render_template(:show)
+        when :json
+          # object.to_json
+          attributes = attributes_for(factory).map{ |k, _| [k, object.send(k)] }.to_h
+          expect(json_response).to eq(attributes)
+        end
       end
     end
   end
@@ -62,11 +104,20 @@ RSpec.shared_examples_for 'a resourceful controller' do |model, raw_options|
     let(:object) { create(factory) }
     subject { get :edit, id: object.id }
 
-    it "renders the edit page" do
-      if tests.include? :edit
+    it 'is successful' do
+      if endpoints_to_test.include? :edit
         subject
         expect(response).to have_http_status(:ok)
-        expect(response).to render_template(:edit)
+      end
+    end
+
+    it "renders the edit page" do
+      if endpoints_to_test.include? :edit
+        subject
+        case endpoint_formats[:edit]
+        when :html
+          expect(response).to render_template(:edit)
+        end
       end
     end
   end
@@ -77,7 +128,7 @@ RSpec.shared_examples_for 'a resourceful controller' do |model, raw_options|
     subject { patch :update, id: object.id, symbol => new_attributes }
 
     it "updates the object" do
-      if tests.include? :update
+      if endpoints_to_test.include? :update
         subject
         object.reload
         new_attributes.each do |k, v|
@@ -92,7 +143,7 @@ RSpec.shared_examples_for 'a resourceful controller' do |model, raw_options|
     subject { delete :destroy, id: object.id }
 
     it "deletes the object" do
-      if tests.include? :destroy
+      if endpoints_to_test.include? :destroy
         expect { subject }.to change { model.count }.by(-1)
       end
     end

--- a/rspec_controller_helpers.gemspec
+++ b/rspec_controller_helpers.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'rspec_controller_helpers'
-  s.version     = '0.0.3'
+  s.version     = '0.0.4'
   s.date        = Time.now.strftime("%Y-%m-%d")
   s.summary     = "Rails controller test helpers"
   s.description = "A few bits and pieces to make testing controllers easier"


### PR DESCRIPTION
### Why?
- JSON endpoints should be tested
### What changed?
- Added some basic json endpoint tests

**NOTE: I plan to support json:api in the future, but this PR doesn't include that**
