### PR TITLE
Can now specify a json key as an options

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ That will test the following:
 | `index`           | `GET /<resource>` | The right number of objects is returned |
 | `show`            | `GET /<resource>/:id` | The correct attributes are returned |
 
-You can also provide the json key value if you're data is nested under that controller name:
+You can also provide the json key value if your data is nested under that controller name:
 
 ````ruby
 it_behaves_like 'a resourceful controller', User, formats: { index: [:html, :json] }, json_key: :users

--- a/README.md
+++ b/README.md
@@ -68,3 +68,14 @@ That will test the following:
 |-------------------|-----------|-------|
 | `index`           | `GET /<resource>` | The right number of objects is returned |
 | `show`            | `GET /<resource>/:id` | The correct attributes are returned |
+
+You can also provide the json key value if you're data is nested under that controller name:
+
+````ruby
+it_behaves_like 'a resourceful controller', User, formats: { index: [:html, :json] }, json_key: :users
+
+"users":
+[
+  { ... }
+]
+````

--- a/lib/rspec_controller_helpers/resourceful.rb
+++ b/lib/rspec_controller_helpers/resourceful.rb
@@ -10,6 +10,7 @@ RSpec.shared_examples_for 'a resourceful controller' do |model, raw_options|
   let(:model_name) { options[:model_name] || model.name.downcase.to_sym }
   let(:factory) { options[:factory] || model_name }
   let(:endpoints) { options[:only] - options[:except] }
+  let(:json_option) { options[:json_key] }
 
   let(:formats) do
     endpoints
@@ -18,7 +19,13 @@ RSpec.shared_examples_for 'a resourceful controller' do |model, raw_options|
       .merge(options[:formats])
   end
 
-  let(:json_response) { JSON.parse(response.body) }
+  let(:json_response) do
+    if json_option.nil?
+      JSON.parse(response.body)
+    else
+      JSON.parse(response.body)[json_option.to_s].first
+    end
+  end
 
   describe "GET /<resource>" do
     let!(:objects) { create_list(factory, 3) }


### PR DESCRIPTION
# What Changed?
- Add the ability to pass a json key option so it works when using active model serializers json format.
# Why?
- The gem broke when I added active model serializers
